### PR TITLE
Feature/add unauthorised user

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -96,7 +96,7 @@ func FlorenceLoginHandlerPOST(ctx context.Context, usersFile string, privateKeyP
 		// Verify the user by email
 		user, err := utils.VerifyUser(ctx, usersFile, username)
 		if err != nil {
-			log.Error(ctx, "Inavlid user", err)
+			log.Error(ctx, "Invalid user", err)
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}

--- a/templates/user.login.html
+++ b/templates/user.login.html
@@ -10,6 +10,8 @@
     <input type="radio" id="user{{.Username}}" name="username" value="{{.Email}}">
     <label for="user{{.Username}}">{{.Forename}} {{.Surname}} ({{.Email}})</label><br>
     {{end}}
+    <input type="radio" id="invalid_username" name="username" value="Invalid@ons.gov.uk">
+    <label for="invalid_username">Invalid User (Invalid@ons.gov.uk)</label><br>
     <br>
     <input type="hidden" id="redirect" name="redirect" value="{{.RedirectURL}}" />
     <input type="submit" value="Submit">


### PR DESCRIPTION
### What

Added an unauthorised user to login page to verify that **only authorised users** are able to login.

### How to review

- Run dataset-catalogue stack and have the logs open for 'dis-authentication-stub'
- Open up [login page](http://localhost:29500/florence/login) 
- Select the 'Invalid user' and press submit
- Browser should display an 400 error code
- Logs should show a 'user not found' error followed by an 'Invalid user' error

### Who can review

Anyone
