### PR TITLE
Feature/allow v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@
 .idea/
 *.iml
 *.iws
+
+# Go
+.go/
+
+# Key files
+*.key

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,5 +1,7 @@
 FROM golang:1.23.2-bullseye AS base
 
+RUN git config --global --add safe.directory /go
+
 ENV GOCACHE=/go/.go/cache GOPATH=/go/.go/path TZ=Europe/London
 
 # Map between the working directories of dev and live

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This project provides an authentication service stub for testing login and authentication processes without relying on `dp-identity-api`, `Florence`, or `Cognito`. The `dis-authentication-stub` simulates essential login, token renewal, and proxy functionality, allowing local testing for services such as dp-dataset-api when running in "private endpoints enabled" mode.
 
-### Getting started
+## Getting started
 
 To run the service locally:
 
-* Run `make debug` to run application on http://localhost:29500
+* Run `make debug` to run application on <http://localhost:29500>
 
 Additional Commands:
 
@@ -23,34 +23,34 @@ This stub provides the following endpoints to facilitate testing of authenticati
 
 1. Health Check
 
-   - GET /health: Returns 200 OK to confirm the service is running.
+   * GET /health: Returns 200 OK to confirm the service is running.
 
 2. Login Simulation
 
-    - GET /florence/login: Displays a form with a list of configured users. Accepts an optional redirect query parameter (default is /florence/collections).
+    * GET /florence/login: Displays a form with a list of configured users. Accepts an optional redirect query parameter (default is /florence/collections).
 
-    - POST /florence/login: Processes the form submission, setting the following cookies:
-        - access_token: Signed JWT for the selected user.
-        - id_token: Signed JWT for the selected user.
-        - refresh_token: Random opaque token stored in memory.
+    * POST /florence/login: Processes the form submission, setting the following cookies:
+        * access_token: Signed JWT for the selected user.
+        * id_token: Signed JWT for the selected user.
+        * refresh_token: Random opaque token stored in memory.
 
 3. Token Management
 
-    - DELETE /tokens/self: Logs out the user by removing session entries and expiring the id_token, access_token, and refresh_token cookies.
+    * DELETE /tokens/self: Logs out the user by removing session entries and expiring the id_token, access_token, and refresh_token cookies.
 
-    - PUT /tokens/self: Reads the refresh_token cookie to renew the access and ID tokens if valid. Returns 400 if missing or 403 if expired.
+    * PUT /tokens/self: Reads the refresh_token cookie to renew the access and ID tokens if valid. Returns 400 if missing or 403 if expired.
 
 4. JWT Key Retrieval
 
-    - GET /jwt-keys: Returns a JSON map of public JWT signing keys, matching the format of dp-identity-api.
+    * GET /jwt-keys: Returns a JSON map of public JWT signing keys, matching the format of dp-identity-api.
 
 5. API Reverse Proxy
 
-    - /api/: Proxies requests to APIs and sets the Authorization header with the access_token cookie value.
+    * /api/: Proxies requests to APIs and sets the Authorization header with the access_token cookie value.
 
 6. Service Identity Validation
 
-    -   GET /identity: Verifies the service token in the Authorization header. Returns the app ID if valid, or 403 Forbidden otherwise.
+    * GET /identity: Verifies the service token in the Authorization header. Returns the app ID if valid, or 403 Forbidden otherwise.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -54,16 +54,17 @@ This stub provides the following endpoints to facilitate testing of authenticati
 
 ### Configuration
 
-| Environment variable         | Default            | Description
-| ---------------------------- | ------------------ | -----------
-| BIND_ADDR                    | :29500         | The host and port to bind to
-| GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                 | The graceful shutdown timeout in seconds (`time.Duration` format)
-| HEALTHCHECK_INTERVAL         | 30s                | Time between self-healthchecks (`time.Duration` format)
-| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
-| OTEL_EXPORTER_OTLP_ENDPOINT  | localhost:4317     | Endpoint for OpenTelemetry service
-| OTEL_SERVICE_NAME            | dis-authentication-stub          | Label of service for OpenTelemetry service
-| OTEL_BATCH_TIMEOUT           | 5s                 | Timeout for OpenTelemetry
-| OTEL_ENABLED                 | false              | Feature flag to enable OpenTelemetry
+| Environment variable         | Default                 | Description                                                                                                        |
+|------------------------------|-------------------------|--------------------------------------------------------------------------------------------------------------------|
+| API_VERSIONS                 | "", "v1"                | To provision for versioned API endpoints                                                                           |
+| BIND_ADDR                    | :29500                  | The host and port to bind to                                                                                       |
+| GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                      | The graceful shutdown timeout in seconds (`time.Duration` format)                                                  |
+| HEALTHCHECK_INTERVAL         | 30s                     | Time between self-healthchecks (`time.Duration` format)                                                            |
+| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                     | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format) |
+| OTEL_EXPORTER_OTLP_ENDPOINT  | localhost:4317          | Endpoint for OpenTelemetry service                                                                                 |
+| OTEL_SERVICE_NAME            | dis-authentication-stub | Label of service for OpenTelemetry service                                                                         |
+| OTEL_BATCH_TIMEOUT           | 5s                      | Timeout for OpenTelemetry                                                                                          |
+| OTEL_ENABLED                 | false                   | Feature flag to enable OpenTelemetry                                                                               |
 
 ### Contributing
 

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 
 // Config represents service configuration for dis-authentication-stub
 type Config struct {
+	APIVersions                  []string      `envconfig:"API_VERSIONS"`
 	BindAddr                     string        `envconfig:"BIND_ADDR"`
 	APIRouterURL                 string        `envconfig:"API_ROUTER_URL"`
 	GracefulShutdownTimeout      time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
@@ -38,6 +39,7 @@ func Get() (*Config, error) {
 	}
 
 	cfg = &Config{
+		APIVersions:                  []string{"", "v1"},
 		BindAddr:                     "localhost:29500",
 		APIRouterURL:                 "http://localhost:23200",
 		GracefulShutdownTimeout:      5 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,6 +23,7 @@ func TestConfig(t *testing.T) {
 				configuration, err = Get() // This Get() is only called once, when inside this function
 				So(err, ShouldBeNil)
 				So(configuration, ShouldResemble, &Config{
+					APIVersions:                  []string{"", "v1"},
 					BindAddr:                     "localhost:29500",
 					APIRouterURL:                 "http://localhost:23200",
 					GracefulShutdownTimeout:      5 * time.Second,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dis-authentication-stub
 
-go 1.23.2
+go 1.23
 
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.260.0

--- a/service/service.go
+++ b/service/service.go
@@ -60,21 +60,17 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 
 	r.StrictSlash(true).Path("/health").Methods(http.MethodGet).HandlerFunc(hc.Handler)
 
-	r.Path("/jwt-keys").Methods(http.MethodGet).HandlerFunc(handlers.JWTKeysHandler(ctx, utils.LoadJwtKeys))
-
 	r.Path("/florence/login").Methods(http.MethodGet).HandlerFunc(handlers.FlorenceLoginHandler(ctx, "static/json/users.json", "templates/user.login.html"))
-
 	r.Path("/florence/login").Methods(http.MethodPost).HandlerFunc(handlers.FlorenceLoginHandlerPOST(ctx, "static/json/users.json", "static/keys/private.key"))
-
-	r.Path("/tokens/self").Methods(http.MethodGet).HandlerFunc(handlers.TokenSelfGetHandler(ctx, "templates", "delete.token.html"))
-
-	r.Path("/tokens/self").Methods(http.MethodDelete).HandlerFunc(handlers.TokenSelfDeleteHandler(ctx))
-
-	r.Path("/tokens/self").Methods(http.MethodPut).HandlerFunc(handlers.TokenSelfPutHandler(ctx))
-
-	r.Path("/identity").Methods(http.MethodGet).HandlerFunc(handlers.IdentifyUser(ctx))
-
 	r.Handle("/api/{uri:.*}", apiRouterProxy)
+
+	for _, version := range cfg.APIVersions {
+		r.Path(versionedPath("/jwt-keys", version)).Methods(http.MethodGet).HandlerFunc(handlers.JWTKeysHandler(ctx, utils.LoadJwtKeys))
+		r.Path(versionedPath("/tokens/self", version)).Methods(http.MethodGet).HandlerFunc(handlers.TokenSelfGetHandler(ctx, "templates", "delete.token.html"))
+		r.Path(versionedPath("/tokens/self", version)).Methods(http.MethodDelete).HandlerFunc(handlers.TokenSelfDeleteHandler(ctx))
+		r.Path(versionedPath("/tokens/self", version)).Methods(http.MethodPut).HandlerFunc(handlers.TokenSelfPutHandler(ctx))
+		r.Path(versionedPath("/identity", version)).Methods(http.MethodGet).HandlerFunc(handlers.IdentifyUser(ctx))
+	}
 
 	hc.Start(ctx)
 
@@ -136,4 +132,13 @@ func (svc *Service) Close(ctx context.Context) error {
 
 	log.Info(ctx, "graceful shutdown was successful")
 	return nil
+}
+
+func versionedPath(path string, version string) string {
+	versionedPath := ""
+	if version != "" {
+		versionedPath += "/" + version
+	}
+	versionedPath += path
+	return versionedPath
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -126,38 +126,6 @@ func TestRun(t *testing.T) {
 			})
 		})
 
-		/* ADD CODE OR REMOVE: put this code in, if you have Checkers to register
-		Convey("Given that Checkers cannot be registered", func() {
-			// setup (run before each `Convey` at this scope / indentation):
-			errAddheckFail := errors.New("Error(s) registering checkers for healthcheck")
-			hcMockAddFail := &mock.HealthCheckerMock{
-				AddCheckFunc: func(name string, checker healthcheck.Checker) error { return errAddheckFail },
-				StartFunc:    func(ctx context.Context) {},
-			}
-
-			initMock := &mock.InitialiserMock{
-				DoGetHTTPServerFunc: funcDoGetHTTPServerNil,
-				DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
-					return hcMockAddFail, nil
-				},
-				// ADD CODE: add the checkers that you want to register here
-			}
-			svcErrors := make(chan error, 1)
-			svcList := service.NewServiceList(initMock)
-			_, err := service.Run(ctx, cfg, svcList, testBuildTime, testGitCommit, testVersion, svcErrors)
-
-			Convey("Then service Run fails, but all checks try to register", func() {
-				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldResemble, fmt.Sprintf("unable to register checkers: %s", errAddheckFail.Error()))
-				So(svcList.HealthCheck, ShouldBeTrue)
-				// ADD CODE: add code to confirm checkers exist
-				So(len(hcMockAddFail.AddCheckCalls()), ShouldEqual, 0) // ADD CODE: change the '0' to the number of checkers you have registered
-			})
-			Reset(func() {
-				// This reset is run after each `Convey` at the same scope (indentation)
-			})
-		})*/
-
 		Convey("Given that all dependencies are successfully initialised but the http server fails", func() {
 			// setup (run before each `Convey` at this scope / indentation):
 			initMock := &mock.InitialiserMock{


### PR DESCRIPTION
### What

The stub doesn't serve identity api endpoints on /v1 and this is required for some of the downstream libraries to function: 
e.g. https://github.com/ONSdigital/dp-authorisation/blob/fc2a2432389d73a0866bf99f37c60bd69c01a006/identityclient/client.go#L30 and https://github.com/ONSdigital/dp-jwt-verifier-java/blob/6348dbd2fa9b4889aca62f1d35eea20de33ad05f/src/main/java/com/github/onsdigital/JWTKeyProviderImpl.java#L16

For the identity API endpoints, I have added a config var to allow them to be served in multiple places.

Whilst doing this I have also done some minor tidying in the repo. 

### How to review

Run app, then hit /v1/jwt-keys

### Who can review

Not me. 