### PR TITLE
Feature/add wagtail proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This stub provides the following endpoints to facilitate testing of authenticati
 | OTEL_SERVICE_NAME            | dis-authentication-stub | Label of service for OpenTelemetry service                                                                         |
 | OTEL_BATCH_TIMEOUT           | 5s                      | Timeout for OpenTelemetry                                                                                          |
 | OTEL_ENABLED                 | false                   | Feature flag to enable OpenTelemetry                                                                               |
+| WAGTAIL_URL                  | <http://localhost:8000/wagtail>     | Wagtail CMS URL     |
 
 ### Contributing
 
@@ -72,6 +73,6 @@ See [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ### License
 
-Copyright © 2024, Office for National Statistics (https://www.ons.gov.uk)
+Copyright © 2024, Office for National Statistics (<https://www.ons.gov.uk>)
 
 Released under MIT license, see [LICENSE](LICENSE.md) for details.

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	OTExporterOTLPEndpoint       string        `envconfig:"OTEL_EXPORTER_OTLP_ENDPOINT"`
 	OTServiceName                string        `envconfig:"OTEL_SERVICE_NAME"`
 	OtelEnabled                  bool          `envconfig:"OTEL_ENABLED"`
+	WagtailURL                   string        `envconfig:"WAGTAIL_URL"`
 	AccessTokenValidityDuration  time.Duration `envconfig:"ACCESS_TOKEN_VALIDITY_DURATION"`
 	IDTokenValidityDuration      time.Duration `envconfig:"ID_TOKEN_VALIDITY_DURATION"`
 	RefreshTokenValidityDuration time.Duration `envconfig:"REFRESH_TOKEN_VALIDITY_DURATION"`
@@ -49,6 +50,7 @@ func Get() (*Config, error) {
 		OTExporterOTLPEndpoint:       "localhost:4317",
 		OTServiceName:                "dis-authentication-stub",
 		OtelEnabled:                  false,
+		WagtailURL:                   "http://localhost:8000/wagtail",
 		AccessTokenValidityDuration:  15 * time.Minute,
 		IDTokenValidityDuration:      15 * time.Minute,
 		RefreshTokenValidityDuration: 12 * time.Hour,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,6 +33,7 @@ func TestConfig(t *testing.T) {
 					OTExporterOTLPEndpoint:       "localhost:4317",
 					OTServiceName:                "dis-authentication-stub",
 					OtelEnabled:                  false,
+					WagtailURL:                   "http://localhost:8000/wagtail",
 					AccessTokenValidityDuration:  15 * time.Minute,
 					IDTokenValidityDuration:      15 * time.Minute,
 					RefreshTokenValidityDuration: 12 * time.Hour,

--- a/service/service.go
+++ b/service/service.go
@@ -38,10 +38,18 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 		return nil, err
 	}
 
-	apiRouterProxy := reverseproxy.Create(apiRouterURL, directors.Director("/api"), nil)
+	wagtailURL, err := url.Parse(cfg.WagtailURL)
+	if err != nil {
+		log.Fatal(ctx, "error parsing Wagtail URL", err)
+		return nil, err
+	}
 
+	apiRouterProxy := reverseproxy.Create(apiRouterURL, directors.Director("/api"), nil)
+	wagtailProxy := reverseproxy.Create(wagtailURL, directors.Director("/wagtail"), nil)
+
+	// TODO: Convert router to go http.servemux https://pkg.go.dev/net/http#ServeMux
 	// Get HTTP Server
-	r := mux.NewRouter()
+	r := mux.NewRouter().StrictSlash(false)
 
 	if cfg.OtelEnabled {
 		r.Use(otelmux.Middleware(cfg.OTServiceName))
@@ -50,15 +58,12 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	s := serviceList.GetHTTPServer(cfg.BindAddr, r)
 
 	hc, err := serviceList.GetHealthCheck(cfg, buildTime, gitCommit, version)
-
 	if err != nil {
 		log.Fatal(ctx, "could not instantiate healthcheck", err)
 		return nil, err
 	}
 
-	r.StrictSlash(true).Path("/health").HandlerFunc(hc.Handler)
-
-	r.StrictSlash(true).Path("/health").Methods(http.MethodGet).HandlerFunc(hc.Handler)
+	r.Path("/health").HandlerFunc(hc.Handler)
 
 	r.Path("/florence/login").Methods(http.MethodGet).HandlerFunc(handlers.FlorenceLoginHandler(ctx, "static/json/users.json", "templates/user.login.html"))
 	r.Path("/florence/login").Methods(http.MethodPost).HandlerFunc(handlers.FlorenceLoginHandlerPOST(ctx, "static/json/users.json", "static/keys/private.key"))
@@ -71,6 +76,8 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 		r.Path(versionedPath("/tokens/self", version)).Methods(http.MethodPut).HandlerFunc(handlers.TokenSelfPutHandler(ctx))
 		r.Path(versionedPath("/identity", version)).Methods(http.MethodGet).HandlerFunc(handlers.IdentifyUser(ctx))
 	}
+
+	r.Handle("/wagtail{uri:.*}", wagtailProxy)
 
 	hc.Start(ctx)
 


### PR DESCRIPTION
### What

Added proxy to `wagtail`
Verbosely set `StrictSlash` to `false` as this was causing a circular redirect loop for `/wagtail` and the `/health` endpoint doesn't need it
ALSO there doesn't need to be two paths to the same handler that do the same thing...

### How to review

Sense check

### Who can review

!me
