### PR TITLE
Add reverse proxy for data-admin-ui

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	OTServiceName                string        `envconfig:"OTEL_SERVICE_NAME"`
 	OtelEnabled                  bool          `envconfig:"OTEL_ENABLED"`
 	WagtailURL                   string        `envconfig:"WAGTAIL_URL"`
+	DataAdminURL                 string        `envconfig:"DATA_ADMIN_URL"`
 	AccessTokenValidityDuration  time.Duration `envconfig:"ACCESS_TOKEN_VALIDITY_DURATION"`
 	IDTokenValidityDuration      time.Duration `envconfig:"ID_TOKEN_VALIDITY_DURATION"`
 	RefreshTokenValidityDuration time.Duration `envconfig:"REFRESH_TOKEN_VALIDITY_DURATION"`
@@ -52,6 +53,7 @@ func Get() (*Config, error) {
 		OTServiceName:                "dis-authentication-stub",
 		OtelEnabled:                  false,
 		WagtailURL:                   "http://localhost:8000/wagtail",
+		DataAdminURL:                 "http://localhost:29400/data-admin",
 		AccessTokenValidityDuration:  15 * time.Minute,
 		IDTokenValidityDuration:      15 * time.Minute,
 		RefreshTokenValidityDuration: 12 * time.Hour,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,6 +34,7 @@ func TestConfig(t *testing.T) {
 					OTServiceName:                "dis-authentication-stub",
 					OtelEnabled:                  false,
 					WagtailURL:                   "http://localhost:8000/wagtail",
+					DataAdminURL:                 "http://localhost:29400/data-admin",
 					AccessTokenValidityDuration:  15 * time.Minute,
 					IDTokenValidityDuration:      15 * time.Minute,
 					RefreshTokenValidityDuration: 12 * time.Hour,

--- a/service/service.go
+++ b/service/service.go
@@ -44,8 +44,15 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 		return nil, err
 	}
 
+	dataAdminURL, err := url.Parse(cfg.DataAdminURL)
+	if err != nil {
+		log.Fatal(ctx, "error parsing Data Admin URL", err)
+		return nil, err
+	}
+
 	apiRouterProxy := reverseproxy.Create(apiRouterURL, directors.Director("/api"), nil)
 	wagtailProxy := reverseproxy.Create(wagtailURL, directors.Director("/wagtail"), nil)
+	dataAdminProxy := reverseproxy.Create(dataAdminURL, directors.Director("/data-admin"), nil)
 
 	// TODO: Convert router to go http.servemux https://pkg.go.dev/net/http#ServeMux
 	// Get HTTP Server
@@ -85,6 +92,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	}
 
 	r.Handle("/wagtail{uri:.*}", wagtailProxy)
+	r.Handle("/data-admin{uri:.*}", dataAdminProxy)
 
 	hc.Start(ctx)
 


### PR DESCRIPTION
### What

Add reverse proxy for data-admin-ui

### How to review

Whilst running both `dis-authentication-stub` and `dis-data-admin-ui` in the same way, e.g. both separately in terminal windows (to work via `dp-compose` requires this [PR](https://github.com/ONSdigital/dp-compose/pull/250). Try access `dis-data-admin-ui`via the proxy go to http://localhost:29500/data-admin/series

### Who can review

Anyone
