### PR TITLE
allow access token identification

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -363,13 +363,7 @@ func IdentifyUser(ctx context.Context, serviceAuthTokenMap map[string]string) ht
 			return
 		}
 
-		// Check if X-Florence-Token header is present
-		if req.Header.Get("X-Florence-Token") != "" {
-			writeIdentifierResponse(ctx, w, "X-Florence-Token")
-			return
-		}
-
-		// Service token did not match with any in serviceAuthTokenMap, AccessTokenStore and X-Florence-Token header not present
+		// Service token did not match with any in serviceAuthTokenMap and AccessTokenStore
 		w.WriteHeader(http.StatusForbidden)
 	}
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ONSdigital/dis-authentication-stub/config"
 	"github.com/ONSdigital/dis-authentication-stub/models"
 	"github.com/ONSdigital/dis-authentication-stub/static"
-	"github.com/ONSdigital/dis-authentication-stub/utils"
 
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/golang-jwt/jwt"
@@ -124,6 +123,9 @@ func FlorenceLoginHandlerPOST(ctx context.Context, store static.Store) http.Hand
 			log.Error(ctx, "Failed to generate access token JWT", err)
 			w.WriteHeader(http.StatusInternalServerError)
 		}
+
+		// Store access token in the in-memory map
+		models.AccessTokenStore[strings.TrimPrefix(accessToken, BearerPrefix)] = user.Username
 
 		idToken, err := generateIDTokenJWT(store, *user, cfg.IDTokenValidityDuration)
 		if err != nil {
@@ -338,10 +340,8 @@ func TokenSelfPutHandler(ctx context.Context, store static.Store) http.HandlerFu
 	}
 }
 
-// Verify the service token exists within config
-func IdentifyUser(ctx context.Context) http.HandlerFunc {
+func IdentifyUser(ctx context.Context, serviceAuthTokenMap map[string]string) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		// Retrieve Authorization header
 		authorizationHeader := req.Header.Get("Authorization")
 		if authorizationHeader == "" {
 			log.Error(ctx, "Authorization header missing", nil)
@@ -349,24 +349,38 @@ func IdentifyUser(ctx context.Context) http.HandlerFunc {
 			return
 		}
 
-		// Check if service token from header matches one in config
-		cfg, _ := config.Get()
-		serviceAuthTokens := utils.GetServiceAuthTokens(*cfg)
-		serviceToken := strings.Replace(authorizationHeader, BearerPrefix, "", 1)
-		xFlorenceHeader := req.Header.Get("X-Florence-Token")
-		if serviceAuthTokens[serviceToken] != "" || xFlorenceHeader != "" {
-			response := map[string]string{"identifier": serviceAuthTokens[serviceToken]}
-			if err := json.NewEncoder(w).Encode(response); err != nil {
-				log.Error(ctx, "Error encoding response", err)
-				w.WriteHeader(http.StatusInternalServerError)
-			} else {
-				w.WriteHeader(http.StatusOK)
-			}
+		serviceToken := strings.TrimPrefix(authorizationHeader, BearerPrefix)
+
+		// Check if the service token matches any in serviceAuthTokenMap, identifier will be the service name
+		if identifier := serviceAuthTokenMap[serviceToken]; identifier != "" {
+			writeIdentifierResponse(ctx, w, identifier)
 			return
 		}
 
-		// Service token did not match with any in config
+		// Check if the service token matches any in AccessTokenStore, identifer will be the username
+		if identifier := models.AccessTokenStore[serviceToken]; identifier != "" {
+			writeIdentifierResponse(ctx, w, identifier)
+			return
+		}
+
+		// Check if X-Florence-Token header is present
+		if req.Header.Get("X-Florence-Token") != "" {
+			writeIdentifierResponse(ctx, w, "X-Florence-Token")
+			return
+		}
+
+		// Service token did not match with any in serviceAuthTokenMap, AccessTokenStore and X-Florence-Token header not present
 		w.WriteHeader(http.StatusForbidden)
+	}
+}
+
+func writeIdentifierResponse(ctx context.Context, w http.ResponseWriter, identifier string) {
+	response := map[string]string{"identifier": identifier}
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Error(ctx, "Error encoding response", err)
+		w.WriteHeader(http.StatusInternalServerError)
+	} else {
+		w.WriteHeader(http.StatusOK)
 	}
 }
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -735,24 +735,6 @@ func TestIdentifyUser_Success(t *testing.T) {
 				So(response["identifier"], ShouldEqual, "some-uuid-username")
 			})
 		})
-
-		Convey("When the service token is not within the serviceAuthTokenMap or AccessTokenStore but an X-Florence-Token header is provided", func() {
-			request := httptest.NewRequest(http.MethodGet, "/identity", http.NoBody)
-			request.Header.Set("Authorization", "invalid-token")
-			request.Header.Set("X-Florence-Token", "some-token")
-
-			responseRecorder := httptest.NewRecorder()
-			handler.ServeHTTP(responseRecorder, request)
-
-			Convey("Then it should return 200 with expected JSON body", func() {
-				So(responseRecorder.Code, ShouldEqual, http.StatusOK)
-
-				var response map[string]string
-				err := json.NewDecoder(responseRecorder.Body).Decode(&response)
-				So(err, ShouldBeNil)
-				So(response["identifier"], ShouldEqual, "X-Florence-Token")
-			})
-		})
 	})
 }
 
@@ -778,7 +760,7 @@ func TestIdentifyUser_Failure(t *testing.T) {
 			})
 		})
 
-		Convey("When the service token is not within the serviceAuthTokenMap, AccessTokenStore and there is no X-Florence-Token header", func() {
+		Convey("When the service token is not within the serviceAuthTokenMap or AccessTokenStore", func() {
 			request := httptest.NewRequest(http.MethodGet, "/identity", http.NoBody)
 			request.Header.Set("Authorization", "Bearer invalid-token")
 			responseRecorder := httptest.NewRecorder()

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ONSdigital/dis-authentication-stub/config"
 	"github.com/ONSdigital/dis-authentication-stub/models"
 	"github.com/ONSdigital/dis-authentication-stub/static/mock"
+	"github.com/ONSdigital/dis-authentication-stub/utils"
 	"github.com/golang-jwt/jwt"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -685,10 +686,86 @@ func TestTokenSelfPutHandler(t *testing.T) {
 	})
 }
 
-func TestIdentifyUser(t *testing.T) {
+func TestIdentifyUser_Success(t *testing.T) {
 	Convey("Given a context and IdentifyUser handler", t, func() {
 		ctx := context.Background()
-		handler := IdentifyUser(ctx)
+
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+
+		serviceAuthTokenMap := utils.GetServiceAuthTokens(*cfg)
+
+		existingKeyWithinServiceAuthTokenMap := BearerPrefix + cfg.ZebedeeAuthToken
+
+		existingKeyWithinAccessTokenStore := "access-token-store-key"
+		models.AccessTokenStore[existingKeyWithinAccessTokenStore] = "some-uuid-username"
+
+		handler := IdentifyUser(ctx, serviceAuthTokenMap)
+
+		Convey("When the service token is within the serviceAuthTokenMap", func() {
+			request := httptest.NewRequest(http.MethodGet, "/identity", http.NoBody)
+			request.Header.Set("Authorization", existingKeyWithinServiceAuthTokenMap)
+
+			responseRecorder := httptest.NewRecorder()
+			handler.ServeHTTP(responseRecorder, request)
+
+			Convey("Then it should return 200 with expected JSON body", func() {
+				So(responseRecorder.Code, ShouldEqual, http.StatusOK)
+
+				var response map[string]string
+				err := json.NewDecoder(responseRecorder.Body).Decode(&response)
+				So(err, ShouldBeNil)
+				So(response["identifier"], ShouldEqual, "zebedee")
+			})
+		})
+
+		Convey("When the service token is only within the AccessTokenStore", func() {
+			request := httptest.NewRequest(http.MethodGet, "/identity", http.NoBody)
+			request.Header.Set("Authorization", BearerPrefix+existingKeyWithinAccessTokenStore)
+
+			responseRecorder := httptest.NewRecorder()
+			handler.ServeHTTP(responseRecorder, request)
+
+			Convey("Then it should return 200 with expected JSON body", func() {
+				So(responseRecorder.Code, ShouldEqual, http.StatusOK)
+
+				var response map[string]string
+				err := json.NewDecoder(responseRecorder.Body).Decode(&response)
+				So(err, ShouldBeNil)
+				So(response["identifier"], ShouldEqual, "some-uuid-username")
+			})
+		})
+
+		Convey("When the service token is not within the serviceAuthTokenMap or AccessTokenStore but an X-Florence-Token header is provided", func() {
+			request := httptest.NewRequest(http.MethodGet, "/identity", http.NoBody)
+			request.Header.Set("Authorization", "invalid-token")
+			request.Header.Set("X-Florence-Token", "some-token")
+
+			responseRecorder := httptest.NewRecorder()
+			handler.ServeHTTP(responseRecorder, request)
+
+			Convey("Then it should return 200 with expected JSON body", func() {
+				So(responseRecorder.Code, ShouldEqual, http.StatusOK)
+
+				var response map[string]string
+				err := json.NewDecoder(responseRecorder.Body).Decode(&response)
+				So(err, ShouldBeNil)
+				So(response["identifier"], ShouldEqual, "X-Florence-Token")
+			})
+		})
+	})
+}
+
+func TestIdentifyUser_Failure(t *testing.T) {
+	Convey("Given a context and IdentifyUser handler", t, func() {
+		ctx := context.Background()
+
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+
+		serviceAuthTokenMap := utils.GetServiceAuthTokens(*cfg)
+
+		handler := IdentifyUser(ctx, serviceAuthTokenMap)
 
 		Convey("When the Authorization header is missing", func() {
 			request := httptest.NewRequest(http.MethodGet, "/identity", http.NoBody)
@@ -701,7 +778,7 @@ func TestIdentifyUser(t *testing.T) {
 			})
 		})
 
-		Convey("When the Authorization header has an invalid service token", func() {
+		Convey("When the service token is not within the serviceAuthTokenMap, AccessTokenStore and there is no X-Florence-Token header", func() {
 			request := httptest.NewRequest(http.MethodGet, "/identity", http.NoBody)
 			request.Header.Set("Authorization", "Bearer invalid-token")
 			responseRecorder := httptest.NewRecorder()
@@ -710,29 +787,6 @@ func TestIdentifyUser(t *testing.T) {
 
 			Convey("Then it should return 403 Forbidden", func() {
 				So(responseRecorder.Code, ShouldEqual, http.StatusForbidden)
-			})
-		})
-
-		Convey("When the Authorization header has an valid service token", func() {
-			request := httptest.NewRequest(http.MethodGet, "/identity", http.NoBody)
-
-			cfg, err := config.Get()
-			So(err, ShouldBeNil)
-
-			existingAuthToken := BearerPrefix + cfg.ZebedeeAuthToken
-
-			request.Header.Set("Authorization", existingAuthToken)
-			responseRecorder := httptest.NewRecorder()
-
-			handler.ServeHTTP(responseRecorder, request)
-
-			Convey("Then it should return 200 with expected JSON body", func() {
-				So(responseRecorder.Code, ShouldEqual, http.StatusOK)
-
-				var response map[string]string
-				err := json.NewDecoder(responseRecorder.Body).Decode(&response)
-				So(err, ShouldBeNil)
-				So(response["identifier"], ShouldEqual, "zebedee")
 			})
 		})
 	})

--- a/models/access_token.go
+++ b/models/access_token.go
@@ -1,0 +1,4 @@
+package models
+
+// In-memory map to store access tokens, mapping token strings to usernames
+var AccessTokenStore = map[string]string{}

--- a/service/service.go
+++ b/service/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ONSdigital/dis-authentication-stub/directors"
 	"github.com/ONSdigital/dis-authentication-stub/handlers"
 	"github.com/ONSdigital/dis-authentication-stub/static"
+	"github.com/ONSdigital/dis-authentication-stub/utils"
 	"github.com/ONSdigital/dp-net/v2/handlers/reverseproxy"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
@@ -77,6 +78,8 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 		return nil, err
 	}
 
+	serviceAuthTokenMap := utils.GetServiceAuthTokens(*cfg)
+
 	r.Path("/health").HandlerFunc(hc.Handler)
 
 	r.Path("/florence/login").Methods(http.MethodGet).HandlerFunc(handlers.FlorenceLoginHandler(ctx, store))
@@ -93,14 +96,14 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 		r.Path(fmt.Sprintf("%s%s", florenceAPIPrefix, versionedPath("/tokens/self", version))).Methods(http.MethodGet).HandlerFunc(handlers.TokenSelfGetHandler(ctx, store))
 		r.Path(fmt.Sprintf("%s%s", florenceAPIPrefix, versionedPath("/tokens/self", version))).Methods(http.MethodDelete).HandlerFunc(handlers.TokenSelfDeleteHandler(ctx))
 		r.Path(fmt.Sprintf("%s%s", florenceAPIPrefix, versionedPath("/tokens/self", version))).Methods(http.MethodPut).HandlerFunc(handlers.TokenSelfPutHandler(ctx, store))
-		r.Path(fmt.Sprintf("%s%s", florenceAPIPrefix, versionedPath("/identity", version))).Methods(http.MethodGet).HandlerFunc(handlers.IdentifyUser(ctx))
+		r.Path(fmt.Sprintf("%s%s", florenceAPIPrefix, versionedPath("/identity", version))).Methods(http.MethodGet).HandlerFunc(handlers.IdentifyUser(ctx, serviceAuthTokenMap))
 
 		// Fake the API router without the florence proxy
 		r.Path(versionedPath("/jwt-keys", version)).Methods(http.MethodGet).HandlerFunc(handlers.JWTKeysHandler(ctx, store))
 		r.Path(versionedPath("/tokens/self", version)).Methods(http.MethodGet).HandlerFunc(handlers.TokenSelfGetHandler(ctx, store))
 		r.Path(versionedPath("/tokens/self", version)).Methods(http.MethodDelete).HandlerFunc(handlers.TokenSelfDeleteHandler(ctx))
 		r.Path(versionedPath("/tokens/self", version)).Methods(http.MethodPut).HandlerFunc(handlers.TokenSelfPutHandler(ctx, store))
-		r.Path(versionedPath("/identity", version)).Methods(http.MethodGet).HandlerFunc(handlers.IdentifyUser(ctx))
+		r.Path(versionedPath("/identity", version)).Methods(http.MethodGet).HandlerFunc(handlers.IdentifyUser(ctx, serviceAuthTokenMap))
 	}
 
 	r.Handle("/wagtail{uri:.*}", wagtailProxy)


### PR DESCRIPTION
### What

- Create in-memory map for `access_token` so we can verify users this way
- Refactor of `IdentifyUser` function to remove `X-Florence-Token` header checks

### How to review

- Check changes are ok
This can be tested with another PR, https://github.com/ONSdigital/dis-bundle-api/pull/71

### Who can review

Anyone
