### PR TITLE
add access token into store on refresh

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -309,6 +309,9 @@ func TokenSelfPutHandler(ctx context.Context, store static.Store) http.HandlerFu
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 
+		// Store new access token in the in-memory map
+		models.AccessTokenStore[strings.TrimPrefix(newAccessToken, BearerPrefix)] = user.Username
+
 		newIDToken, err := generateIDTokenJWT(store, user, cfg.IDTokenValidityDuration)
 		if err != nil {
 			log.Error(ctx, "failed to generate ID token JWT", err)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -295,15 +295,18 @@ func TokenSelfPutHandler(ctx context.Context, store static.Store) http.HandlerFu
 			return
 		}
 
-		// Retrieve the user details from the in-memory map using the username
-		user := models.User{
-			Username: tokenInfo.Username,
+		// Retrieve the user by email
+		user, err := store.GetUser(tokenInfo.Username)
+		if err != nil {
+			log.Error(ctx, "failed to retrieve user from store", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 
 		cfg, _ := config.Get()
 
 		// Generate new tokens
-		newAccessToken, err := generateAccessTokenJWT(store, user, cfg.AccessTokenValidityDuration)
+		newAccessToken, err := generateAccessTokenJWT(store, *user, cfg.AccessTokenValidityDuration)
 		if err != nil {
 			log.Error(ctx, "failed to generate access token JWT", err)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -312,7 +315,7 @@ func TokenSelfPutHandler(ctx context.Context, store static.Store) http.HandlerFu
 		// Store new access token in the in-memory map
 		models.AccessTokenStore[strings.TrimPrefix(newAccessToken, BearerPrefix)] = user.Username
 
-		newIDToken, err := generateIDTokenJWT(store, user, cfg.IDTokenValidityDuration)
+		newIDToken, err := generateIDTokenJWT(store, *user, cfg.IDTokenValidityDuration)
 		if err != nil {
 			log.Error(ctx, "failed to generate ID token JWT", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -584,6 +584,7 @@ func TestTokenSelfPutHandler(t *testing.T) {
 		mockStore := &mock.StoreMock{
 			GetPrivateKeyFunc: func() *rsa.PrivateKey { return mockKey },
 			GetKidsFunc:       func() []string { return []string{mockKID} },
+			GetUserFunc:       func(email string) (*models.User, error) { return &testUser, nil },
 		}
 
 		handler := TokenSelfPutHandler(ctx, mockStore)

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -670,6 +670,10 @@ func TestTokenSelfPutHandler(t *testing.T) {
 				So(idToken, ShouldNotBeNil)
 				So(idToken.Value, ShouldNotBeEmpty)
 				So(idToken.HttpOnly, ShouldBeFalse)
+
+				Convey("And it should add the access_token into the accessTokenStore", func() {
+					So(models.AccessTokenStore[strings.TrimPrefix(accessToken.Value, BearerPrefix)], ShouldNotBeEmpty)
+				})
 			})
 
 			Convey("And it should pass the expiration date in the payload", func() {


### PR DESCRIPTION
### What

- Add access_token into store on refresh to keep access token valid after refresh

### How to review

- check changes are ok
- Call `/bundles` (any endpoint that uses auth middleware) after logging in as admin from `http://localhost:29500/florence/login`. 200 status code should be returned
- Go to `http://localhost:29500/tokens/self` and click `refresh session` and use the new `access_token` to call `/bundles` again and a 200 status code should be returned. (Previously the new `access_token` generated after the refresh wouldn't be authorised)

### Who can review

Anyone
