### PR TITLE
Remove hyphen from migration service auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This stub provides the following endpoints to facilitate testing of authenticati
 | GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                                | The graceful shutdown timeout in seconds (`time.Duration` format)                                                  |
 | HEALTHCHECK_INTERVAL         | 30s                               | Time between self-healthchecks (`time.Duration` format)                                                            |
 | HEALTHCHECK_CRITICAL_TIMEOUT | 90s                               | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format) |
-| MIGRATION_SERVICE_AUTH_TOKEN | migration-service-test-auth-token | A fake auth token for the migration service to be verified                                                         |
+| MIGRATION_SERVICE_AUTH_TOKEN | migrationservicetestauthtoken | A fake auth token for the migration service to be verified                                                         |
 | OTEL_EXPORTER_OTLP_ENDPOINT  | localhost:4317                    | Endpoint for OpenTelemetry service                                                                                 |
 | OTEL_SERVICE_NAME            | dis-authentication-stub           | Label of service for OpenTelemetry service                                                                         |
 | OTEL_BATCH_TIMEOUT           | 5s                                | Timeout for OpenTelemetry                                                                                          |

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.11-bookworm
+    tag: 1.24.12-bookworm
 
 inputs:
   - name: dis-authentication-stub

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.4-bullseye
+    tag: 1.24.12-bookworm
 
 inputs:
   - name: dis-authentication-stub

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.24.11-bookworm-golangci-lint-2
+    tag: 1.24.12-bookworm-golangci-lint-2
 
 inputs:
   - name: dis-authentication-stub

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.11-bookworm
+    tag: 1.24.12-bookworm
 
 inputs:
   - name: dis-authentication-stub

--- a/config/config.go
+++ b/config/config.go
@@ -62,7 +62,7 @@ func Get() (*Config, error) {
 		DatasetAPIAuthToken:          "dataset-api-test-auth-token",
 		DownloadServiceAuthToken:     "download-service-test-auth-token",
 		FilterAPIAuthToken:           "filter-api-test-auth-token",
-		MigrationServiceAuthToken:    "migration-service-test-auth-token",
+		MigrationServiceAuthToken:    "migrationservicetestauthtoken",
 		StaticFilePublisherAuthToken: "static-file-publisher-test-auth-token",
 		UploadServiceAuthToken:       "upload-service-test-auth-token",
 		ZebedeeAuthToken:             "zebedee-test-auth-token",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -46,7 +46,7 @@ func TestConfig(t *testing.T) {
 					ZebedeeAuthToken:             "zebedee-test-auth-token",
 					WagtailAuthToken:             "wagtail-test-auth-token",
 					BundleSchedulerAuthToken:     "bundle-scheduler-test-auth-token",
-					MigrationServiceAuthToken:    "migration-service-test-auth-token",
+					MigrationServiceAuthToken:    "migrationservicetestauthtoken",
 				})
 			})
 


### PR DESCRIPTION
### What

Remove hypen from migration service auth token - causing errors.

### How to review

Sense check

### Who can review

Not me